### PR TITLE
Correct the order of the language fields in PHP, de and de_x_sie

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -289,8 +289,8 @@ class main_listener implements EventSubscriberInterface
 			'MOVED_MESSAGE',
 			$l_from_forum,
 			$l_to_forum,
-			$this->user->format_date($data['log_time']),
-			get_username_string('full', $data['user_id'], $data['username'], $data['user_colour'])
+			get_username_string('full', $data['user_id'], $data['username'], $data['user_colour']),
+			$this->user->format_date($data['log_time'])
 		);
 
 		$this->template->assign_block_vars($template_block, array(

--- a/language/de/movemessage.php
+++ b/language/de/movemessage.php
@@ -17,5 +17,5 @@ if (empty($lang) || !is_array($lang))
 }
 
 $lang = array_merge($lang, array(
-	'MOVED_MESSAGE'				=> 'Verschoben von <strong>%1$s</strong> nach <strong>%2$s</strong> am %3$s durch <strong>%4$s</strong>',
+	'MOVED_MESSAGE'				=> 'Verschoben von <strong>%1$s</strong> nach <strong>%2$s</strong> am %4$s durch <strong>%3$s</strong>',
 ));

--- a/language/de_x_sie/movemessage.php
+++ b/language/de_x_sie/movemessage.php
@@ -17,5 +17,5 @@ if (empty($lang) || !is_array($lang))
 }
 
 $lang = array_merge($lang, array(
-	'MOVED_MESSAGE'				=> 'Verschoben von <strong>%1$s</strong> nach <strong>%2$s</strong> am %3$s durch <strong>%4$s</strong>',
+	'MOVED_MESSAGE'				=> 'Verschoben von <strong>%1$s</strong> nach <strong>%2$s</strong> am %4$s durch <strong>%3$s</strong>',
 ));


### PR DESCRIPTION
There was a mismatch between the language files and PHP. Since Translations from English have already been turned in, we'll swap PHP and adjust de and de_x_sie so English stays correct.
