### PR TITLE
Change.travis.yml to fix openssl error in PHP 5.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ branches:
     - /^release-.*$/
 
 install:
-  - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - travis/prepare-phpbb.sh $EXTNAME $PHPBB_BRANCH
   - cd ../../phpBB3


### PR DESCRIPTION
To fix those problems: https://travis-ci.org/phpbb-de/phpbb-ext-movemessage/jobs/112434401 

> [RuntimeException]  
> The openssl extension is required for SSL/TLS protection but is not available. If you can not enable the openssl extension, you can disable this error, at your own risk, by setting the 'disable-tls' option to true.  
